### PR TITLE
Added hemispheres argument to avoid warning message

### DIFF
--- a/model/one_region_simu.py
+++ b/model/one_region_simu.py
@@ -102,7 +102,9 @@ def config_one_region():
                                             centres = centres,
                                             cortical = cortical,
                                             orientations = orientations,
-                                            areas = areas,weights = weights)
+                                            areas = areas,weights = weights,
+                                            hemispheres = np.array(True)) # hemispheres takes in an array of booleans 
+                                                                          # where True refers to the right hemisphere and False to the left hemisphere
     one_region.configure()
     return one_region
 


### PR DESCRIPTION
tvb.connectivity.Connectivity tries to import a non-existent hemispheres file from tvb.data if the hemispheres are not specified. The argument specifies the region to be part of the left hemisphere, which is coded as False.